### PR TITLE
Fix/issue#20

### DIFF
--- a/demoUser.sql
+++ b/demoUser.sql
@@ -1,5 +1,5 @@
-insert into member values(101, now(), now(), "test1@test.com", "test1", "social1");
-insert into member values(102, now(), now(), "test2@test.com", "test2", "social2");
-insert into member values(103, now(), now(), "test3@test.com", "test3", "social3");
-insert into member values(104, now(), now(), "test4@test.com", "test4", "social4");
-insert into member values(105, now(), now(), "test5@test.com", "test5", "social5");
+insert into member values(101, now(), now(), "test1@test.com", "test1");
+insert into member values(102, now(), now(), "test2@test.com", "test2");
+insert into member values(103, now(), now(), "test3@test.com", "test3");
+insert into member values(104, now(), now(), "test4@test.com", "test4");
+insert into member values(105, now(), now(), "test5@test.com", "test5");

--- a/src/main/java/com/akkin/auth/presentation/AuthApiControllerDocs.java
+++ b/src/main/java/com/akkin/auth/presentation/AuthApiControllerDocs.java
@@ -22,7 +22,7 @@ public interface AuthApiControllerDocs {
     @Operation(summary = "더미 유저 로그인", description = "테스트용 데이터")
     ResponseEntity<TokenResponse> demoOauthLogin(@PathVariable("id") final Long id);
 
-    @Operation(summary = "아낀 항목 삭제", description = "해당 API를 호출하면 결과에 상관없이 200이 반환됩니다.")
+    @Operation(summary = "로그아웃", description = "해당 API를 호출하면 결과에 상관없이 200이 반환됩니다.")
     @Parameter(in = ParameterIn.HEADER, name = "accessToken", required = false, description = "Access Token")
     @Parameter(in = ParameterIn.HEADER, name = "refreshToken", required = false, description = "Refresh Token")
     ResponseEntity<Void> logout(HttpServletRequest request);

--- a/src/main/java/com/akkin/auth/presentation/AuthApiControllerDocs.java
+++ b/src/main/java/com/akkin/auth/presentation/AuthApiControllerDocs.java
@@ -19,7 +19,7 @@ public interface AuthApiControllerDocs {
     @Operation(summary = "애플 로그인", description = "클라이언트가 로그인 후 받은 토큰을 공개키로 파싱")
     ResponseEntity<TokenResponse> appleOauthLogin(final AppleLoginRequest appleLoginRequest);
 
-    @Operation(summary = "더미 유저 로그인", description = "테스트용 데이터")
+    @Operation(summary = "더미 유저 로그인", description = "101 ~ 105 사이로 입력. 앱스토어 배포시 더미 id를 가능한 높게 줘야함")
     ResponseEntity<TokenResponse> demoOauthLogin(@PathVariable("id") final Long id);
 
     @Operation(summary = "로그아웃", description = "해당 API를 호출하면 결과에 상관없이 200이 반환됩니다.")

--- a/src/main/java/com/akkin/config/SwaggerConfig.java
+++ b/src/main/java/com/akkin/config/SwaggerConfig.java
@@ -1,0 +1,27 @@
+package com.akkin.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+            .version("alpha")
+            .title("아낀거지")
+            .description("api 문서");
+
+        Server server = new Server();
+        server.setUrl("https://www.seuleuleug.site");
+
+        return new OpenAPI()
+            .info(info)
+            .servers(List.of(server));
+    }
+}

--- a/src/main/java/com/akkin/gulbi/application/GulbiService.java
+++ b/src/main/java/com/akkin/gulbi/application/GulbiService.java
@@ -2,6 +2,7 @@ package com.akkin.gulbi.application;
 
 import com.akkin.gulbi.domain.GulbiCategory;
 import com.akkin.gulbi.dto.response.GulbiResponse;
+import com.akkin.gulbi.exception.GulbiCreateLimitException;
 import com.akkin.gulbi.exception.GulbiNotFoundException;
 import com.akkin.gulbi.exception.GulbiNotOwnerException;
 import com.akkin.gulbi.domain.Gulbi;
@@ -29,10 +30,25 @@ public class GulbiService {
     private final MemberService memberService;
 
     public static int DEFAULT_GULBI_PAGE_SIZE = 10;
+    public static int TODAY_CREATE_GULBI_LIMIT = 11;
+
+    public void create(final Long memberId, final GulbiCreateForm form) {
+        final Member member = checkMemberValid(memberId);
+        write(member, form);
+
+    }
+
+    private Member checkMemberValid(final Long memberId) {
+        final Member member = memberService.findMember(memberId);
+        List<Long> gulbiList = gulbiRepository.countTodayGulbiCreate(memberId);
+        if (gulbiList.size() >= TODAY_CREATE_GULBI_LIMIT) {
+            throw new GulbiCreateLimitException("너무 많이 작성했습니다.");
+        }
+        return member;
+    }
 
     @Transactional
-    public void create(final Long memberId, final GulbiCreateForm form) {
-        final Member member = memberService.findMember(memberId);
+    private void write(final Member member, final GulbiCreateForm form) {
         gulbiRepository.save(form.dtoToEntity(member));
     }
 

--- a/src/main/java/com/akkin/gulbi/domain/Gulbi.java
+++ b/src/main/java/com/akkin/gulbi/domain/Gulbi.java
@@ -27,6 +27,8 @@ public class Gulbi extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
+    private String imageUrl;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private GulbiCategory category;
@@ -51,6 +53,7 @@ public class Gulbi extends BaseTimeEntity {
 
     @Builder
     public Gulbi(final Member member,
+                 final String imageUrl,
                  final GulbiCategory category,
                  final String saveContent,
                  final String how,
@@ -60,6 +63,7 @@ public class Gulbi extends BaseTimeEntity {
                  final Integer expectCost,
                  final Integer realCost) {
         this.member = member;
+        this.imageUrl = imageUrl;
         this.category = category;
         this.saveContent = saveContent;
         this.how = how;
@@ -70,6 +74,7 @@ public class Gulbi extends BaseTimeEntity {
     }
 
     public void updateGulbi(final GulbiUpdateForm form) {
+        this.imageUrl = form.getImageUrl();
         this.category = form.getCategory();
         this.saveContent = form.getSaveContent();
         this.how = form.getHow();

--- a/src/main/java/com/akkin/gulbi/domain/Gulbi.java
+++ b/src/main/java/com/akkin/gulbi/domain/Gulbi.java
@@ -39,6 +39,7 @@ public class Gulbi extends BaseTimeEntity {
     @Column(nullable = false)
     private String how;
 
+    // 아낀 시기가 언제인지 저장
     @Column(nullable = false)
     private LocalDateTime savedAt;
 

--- a/src/main/java/com/akkin/gulbi/domain/Gulbi.java
+++ b/src/main/java/com/akkin/gulbi/domain/Gulbi.java
@@ -91,4 +91,7 @@ public class Gulbi extends BaseTimeEntity {
         }
         return true;
     }
+
+    protected Gulbi() {
+    }
 }

--- a/src/main/java/com/akkin/gulbi/dto/request/GulbiCreateForm.java
+++ b/src/main/java/com/akkin/gulbi/dto/request/GulbiCreateForm.java
@@ -19,6 +19,9 @@ public class GulbiCreateForm {
     @Schema(description = "아낀 일")
     private Integer day;
 
+    @Schema(description = "이미지 링크")
+    private String imageUrl;
+
     @Schema(description = "카테고리")
     private GulbiCategory category;
 
@@ -40,6 +43,7 @@ public class GulbiCreateForm {
             .year(year)
             .month(month)
             .day(day)
+            .imageUrl(imageUrl)
             .category(category)
             .saveContent(saveContent)
             .how(how)
@@ -51,6 +55,7 @@ public class GulbiCreateForm {
     public GulbiCreateForm( final Integer year,
                             final Integer month,
                             final Integer day,
+                            final String imageUrl,
                             final GulbiCategory category,
                             final String saveContent,
                             final String how,
@@ -59,6 +64,7 @@ public class GulbiCreateForm {
         this.year = year;
         this.month = month;
         this.day = day;
+        this.imageUrl = imageUrl;
         this.category = category;
         this.saveContent = saveContent;
         this.how = how;

--- a/src/main/java/com/akkin/gulbi/dto/request/GulbiUpdateForm.java
+++ b/src/main/java/com/akkin/gulbi/dto/request/GulbiUpdateForm.java
@@ -18,6 +18,8 @@ public class GulbiUpdateForm {
 
     private Integer day;
 
+    private String imageUrl;
+
     private GulbiCategory category;
 
     private String saveContent;
@@ -34,6 +36,7 @@ public class GulbiUpdateForm {
             .year(year)
             .month(month)
             .day(day)
+            .imageUrl(imageUrl)
             .category(category)
             .saveContent(saveContent)
             .how(how)
@@ -45,6 +48,7 @@ public class GulbiUpdateForm {
     public GulbiUpdateForm( final Integer year,
                             final Integer month,
                             final Integer day,
+                            final String imageUrl,
                             final GulbiCategory category,
                             final String saveContent,
                             final String how,
@@ -53,6 +57,7 @@ public class GulbiUpdateForm {
         this.year = year;
         this.month = month;
         this.day = day;
+        this.imageUrl = imageUrl;
         this.category = category;
         this.saveContent = saveContent;
         this.how = how;

--- a/src/main/java/com/akkin/gulbi/dto/request/GulbiUpdateForm.java
+++ b/src/main/java/com/akkin/gulbi/dto/request/GulbiUpdateForm.java
@@ -30,21 +30,6 @@ public class GulbiUpdateForm {
 
     private Integer realCost;
 
-    public Gulbi dtoToEntity(final Member member) {
-        return Gulbi.builder()
-            .member(member)
-            .year(year)
-            .month(month)
-            .day(day)
-            .imageUrl(imageUrl)
-            .category(category)
-            .saveContent(saveContent)
-            .how(how)
-            .expectCost(expectCost)
-            .realCost(realCost)
-            .build();
-    }
-
     public GulbiUpdateForm( final Integer year,
                             final Integer month,
                             final Integer day,

--- a/src/main/java/com/akkin/gulbi/dto/response/GulbiListResponse.java
+++ b/src/main/java/com/akkin/gulbi/dto/response/GulbiListResponse.java
@@ -3,6 +3,7 @@ package com.akkin.gulbi.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -22,5 +23,16 @@ public class GulbiListResponse {
         if (!entries.isEmpty()) {
             lastId = entries.get(entries.size() - 1).getId();
         }
+    }
+
+    public GulbiResponse getElement(int index) {
+        /**
+         * 현재 entries 인덱스를 가지고 원소에 접근할 일이 없음.
+         * 테스트 코드 외 상황에서 범위 접근이필요한 경우 Optional 이나 null 예외 처리 구현 필요
+         */
+        if (entries.size() <= index) {
+            return null;
+        }
+        return entries.get(index);
     }
 }

--- a/src/main/java/com/akkin/gulbi/dto/response/GulbiListResponse.java
+++ b/src/main/java/com/akkin/gulbi/dto/response/GulbiListResponse.java
@@ -1,6 +1,7 @@
 package com.akkin.gulbi.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Collections;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
@@ -17,7 +18,7 @@ public class GulbiListResponse {
     private long lastId = 0L;
 
     public GulbiListResponse(final List<GulbiResponse> entries) {
-        this.entries = entries;
+        this.entries = Collections.unmodifiableList(entries);
         if (!entries.isEmpty()) {
             lastId = entries.get(entries.size() - 1).getId();
         }

--- a/src/main/java/com/akkin/gulbi/dto/response/GulbiResponse.java
+++ b/src/main/java/com/akkin/gulbi/dto/response/GulbiResponse.java
@@ -22,6 +22,9 @@ public class GulbiResponse {
     @Schema(description = "생성 일")
     private Integer day;
 
+    @Schema(description = "이미지 링크")
+    private String imageUrl;
+
     @Schema(description = "카테고리(식비, 교통, 쇼핑 ,기타")
     private GulbiCategory gulbiCategory;
 
@@ -41,6 +44,7 @@ public class GulbiResponse {
                          final Integer year,
                          final Integer month,
                          final Integer day,
+                         final String imageUrl,
                          final GulbiCategory gulbiCategory,
                          final String saveContent,
                          final String how,
@@ -50,6 +54,7 @@ public class GulbiResponse {
         this.year = year;
         this.month = month;
         this.day = day;
+        this.imageUrl = imageUrl;
         this.gulbiCategory = gulbiCategory;
         this.saveContent = saveContent;
         this.how = how;

--- a/src/main/java/com/akkin/gulbi/exception/GulbiCreateLimitException.java
+++ b/src/main/java/com/akkin/gulbi/exception/GulbiCreateLimitException.java
@@ -1,0 +1,8 @@
+package com.akkin.gulbi.exception;
+
+public class GulbiCreateLimitException extends RuntimeException {
+
+    public GulbiCreateLimitException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/akkin/gulbi/persistence/GulbiRepository.java
+++ b/src/main/java/com/akkin/gulbi/persistence/GulbiRepository.java
@@ -26,7 +26,7 @@ public interface GulbiRepository extends JpaRepository<Gulbi, Long> {
         "FROM Gulbi g LEFT JOIN g.member m " +
         "WHERE m.id = :memberId " +
         "AND g.id < :lastId " +
-        "ORDER BY g.id DESC")
+        "ORDER BY g.savedAt DESC, g.id DESC")
     List<GulbiResponse> findGulbiResponseByMemberId(@Param("memberId") Long memberId,
                                                     @Param("lastId") long lastId,
                                                     Pageable pageable);
@@ -45,7 +45,7 @@ public interface GulbiRepository extends JpaRepository<Gulbi, Long> {
         "WHERE m.id = :memberId " +
         "AND g.id < :lastId " +
         "AND g.category = :category " +
-        "ORDER BY g.id DESC")
+        "ORDER BY g.savedAt DESC, g.id DESC")
     List<GulbiResponse> findGulbiResponseByMemberIdAndCategory(@Param("memberId") Long memberId,
                                                                @Param("category") GulbiCategory category,
                                                                @Param("lastId") long lastId,

--- a/src/main/java/com/akkin/gulbi/persistence/GulbiRepository.java
+++ b/src/main/java/com/akkin/gulbi/persistence/GulbiRepository.java
@@ -28,7 +28,7 @@ public interface GulbiRepository extends JpaRepository<Gulbi, Long> {
         "AND g.id < :lastId " +
         "ORDER BY g.savedAt DESC, g.id DESC")
     List<GulbiResponse> findGulbiResponseByMemberId(@Param("memberId") Long memberId,
-                                                    @Param("lastId") long lastId,
+                                                    @Param("lastId") Long lastId,
                                                     Pageable pageable);
 
     @Query("SELECT new com.akkin.gulbi.dto.response.GulbiResponse(g.id, " +
@@ -48,8 +48,20 @@ public interface GulbiRepository extends JpaRepository<Gulbi, Long> {
         "ORDER BY g.savedAt DESC, g.id DESC")
     List<GulbiResponse> findGulbiResponseByMemberIdAndCategory(@Param("memberId") Long memberId,
                                                                @Param("category") GulbiCategory category,
-                                                               @Param("lastId") long lastId,
+                                                               @Param("lastId") Long lastId,
                                                                Pageable pageable);
 
+
+    @Query("SELECT g.id " +
+           "FROM Gulbi g " +
+           "WHERE g.member.id = :memberId " +
+           "AND YEAR(g.savedAt) = YEAR(CURRENT_DATE) " +
+           "AND MONTH(g.savedAt) = MONTH(CURRENT_DATE) " +
+           "AND DAY(g.savedAt) = DAY(CURRENT_DATE) "
+    )
+    List<Long> countTodayGulbiCreate(@Param("memberId") Long memberId);
+
     void deleteAllByMember(Member member);
+
+
 }

--- a/src/main/java/com/akkin/gulbi/persistence/GulbiRepository.java
+++ b/src/main/java/com/akkin/gulbi/persistence/GulbiRepository.java
@@ -17,6 +17,7 @@ public interface GulbiRepository extends JpaRepository<Gulbi, Long> {
         "                                                         YEAR(g.savedAt), " +
         "                                                         MONTH(g.savedAt), " +
         "                                                         DAY(g.savedAt), " +
+        "                                                         g.imageUrl, " +
         "                                                         g.category, " +
         "                                                         g.saveContent, " +
         "                                                         g.how, " +
@@ -34,6 +35,7 @@ public interface GulbiRepository extends JpaRepository<Gulbi, Long> {
         "                                                         YEAR(g.savedAt), " +
         "                                                         MONTH(g.savedAt), " +
         "                                                         DAY(g.savedAt), " +
+        "                                                         g.imageUrl, " +
         "                                                         g.category, " +
         "                                                         g.saveContent, " +
         "                                                         g.how, " +

--- a/src/test/java/com/akkin/fixture/GulbiFixture.java
+++ b/src/test/java/com/akkin/fixture/GulbiFixture.java
@@ -12,6 +12,7 @@ public class GulbiFixture {
         GulbiCategory gulbiCategory, String content, String how, int expectCost, int realCost) {
         return Gulbi.builder()
             .member(member)
+            .imageUrl("image")
             .year(year)
             .month(month)
             .day(day)
@@ -26,6 +27,7 @@ public class GulbiFixture {
     public static Gulbi 식비_500원_아낀_항목_만들기(Member member, int year, int month, int day) {
         return Gulbi.builder()
             .member(member)
+            .imageUrl("image")
             .year(year)
             .month(month)
             .day(day)
@@ -40,6 +42,7 @@ public class GulbiFixture {
     public static Gulbi 교통_500원_아낀_항목_만들기(Member member, int year, int month, int day) {
         return Gulbi.builder()
             .member(member)
+            .imageUrl("image")
             .year(year)
             .month(month)
             .day(day)
@@ -54,6 +57,7 @@ public class GulbiFixture {
     public static Gulbi 쇼핑_500원_아낀_항목_만들기(Member member, int year, int month, int day) {
         return Gulbi.builder()
             .member(member)
+            .imageUrl("image")
             .year(year)
             .month(month)
             .day(day)
@@ -68,6 +72,7 @@ public class GulbiFixture {
     public static Gulbi 기타_500원_아낀_항목_만들기(Member member, int year, int month, int day) {
         return Gulbi.builder()
             .member(member)
+            .imageUrl("image")
             .year(year)
             .month(month)
             .day(day)
@@ -80,6 +85,6 @@ public class GulbiFixture {
     }
 
     public static GulbiCreateForm 아낀_항목_생성_폼_만들기(GulbiCategory gulbiCategory) {
-        return new GulbiCreateForm(2023, 10, 9, gulbiCategory, "content", "how", 1000, 500);
+        return new GulbiCreateForm(2023, 10, 9, "imageUrl", gulbiCategory, "content", "how", 1000, 500);
     }
 }

--- a/src/test/java/com/akkin/fixture/GulbiFixture.java
+++ b/src/test/java/com/akkin/fixture/GulbiFixture.java
@@ -3,6 +3,7 @@ package com.akkin.fixture;
 import com.akkin.gulbi.domain.GulbiCategory;
 import com.akkin.gulbi.domain.Gulbi;
 import com.akkin.gulbi.dto.request.GulbiCreateForm;
+import com.akkin.gulbi.dto.request.GulbiUpdateForm;
 import com.akkin.member.domain.Member;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -86,5 +87,18 @@ public class GulbiFixture {
 
     public static GulbiCreateForm 아낀_항목_생성_폼_만들기(GulbiCategory gulbiCategory) {
         return new GulbiCreateForm(2023, 10, 9, "imageUrl", gulbiCategory, "content", "how", 1000, 500);
+    }
+
+    public static GulbiUpdateForm 아낀_날짜_수정_폼_만들기(Gulbi gulbi, int year, int month, int day) {
+        return new GulbiUpdateForm( year,
+                                    month,
+                                    day,
+                                    gulbi.getImageUrl(),
+                                    gulbi.getCategory(),
+                                    gulbi.getSaveContent(),
+                                    gulbi.getHow(),
+                                    gulbi.getExpectCost(),
+                                    gulbi.getRealCost()
+        );
     }
 }

--- a/src/test/java/com/akkin/gulbi/GulbiCreateTest.java
+++ b/src/test/java/com/akkin/gulbi/GulbiCreateTest.java
@@ -4,11 +4,18 @@ import com.akkin.common.UnitTest;
 import com.akkin.gulbi.domain.GulbiCategory;
 import com.akkin.gulbi.domain.Gulbi;
 import com.akkin.gulbi.dto.request.GulbiCreateForm;
+import com.akkin.gulbi.exception.GulbiCreateLimitException;
+import com.akkin.member.domain.Member;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
+import static com.akkin.fixture.GulbiFixture.기타_500원_아낀_항목_만들기;
 import static com.akkin.fixture.GulbiFixture.아낀_항목_생성_폼_만들기;
 import static com.akkin.fixture.MemberFixture.회원1_만들기;
+import static com.akkin.gulbi.application.GulbiService.TODAY_CREATE_GULBI_LIMIT;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class GulbiCreateTest extends UnitTest {
@@ -63,5 +70,20 @@ public class GulbiCreateTest extends UnitTest {
 
         // then
         assertThat(gulbi.getCategory()).isEqualTo(GulbiCategory.ETC);
+    }
+
+    @Test
+    public void 하루에_지정된_횟수만_생성가능() {
+        // given
+        Member member = memberRepository.save(회원1_만들기());
+        LocalDateTime now = LocalDateTime.now();
+        for (int i = 0; i < TODAY_CREATE_GULBI_LIMIT; i++) {
+            gulbiRepository.save(기타_500원_아낀_항목_만들기(member, now.getYear(), now.getMonthValue(), now.getDayOfMonth()));
+        }
+
+        // when & then
+        assertThrows(GulbiCreateLimitException.class, () -> {
+            gulbiService.create(member.getId(), 아낀_항목_생성_폼_만들기(GulbiCategory.ETC));
+        });
     }
 }

--- a/src/test/java/com/akkin/gulbi/GulbiReadTest.java
+++ b/src/test/java/com/akkin/gulbi/GulbiReadTest.java
@@ -2,14 +2,17 @@ package com.akkin.gulbi;
 
 import static com.akkin.fixture.GulbiFixture.교통_500원_아낀_항목_만들기;
 import static com.akkin.fixture.GulbiFixture.기타_500원_아낀_항목_만들기;
+import static com.akkin.fixture.GulbiFixture.아낀_날짜_수정_폼_만들기;
 import static com.akkin.fixture.MemberFixture.회원1_만들기;
 import static com.akkin.fixture.MemberFixture.회원2_만들기;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.akkin.common.UnitTest;
 import com.akkin.gulbi.domain.Gulbi;
+import com.akkin.gulbi.dto.request.GulbiUpdateForm;
 import com.akkin.gulbi.dto.response.GulbiListResponse;
 import com.akkin.member.domain.Member;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -139,5 +142,21 @@ public class GulbiReadTest extends UnitTest {
         assertThat(results.getElement(1).getId()).isEqualTo(gulbi4.getId());
         assertThat(results.getElement(2).getId()).isEqualTo(gulbi1.getId());
         assertThat(results.getElement(3).getId()).isEqualTo(gulbi2.getId());
+    }
+    
+    @Test
+    public void 아낀_항목_날짜_수정() {
+        // given
+        Member member = memberRepository.save(회원1_만들기());
+        Gulbi before = gulbiRepository.save(기타_500원_아낀_항목_만들기(member, 2023, 9, 9));
+        LocalDateTime beforeSavedAt = before.getSavedAt();
+        GulbiUpdateForm updateForm = 아낀_날짜_수정_폼_만들기(before, 2023, 9, 10);
+        gulbiService.update(member.getId(), before.getId(), updateForm);
+
+        // when
+        Gulbi after = gulbiRepository.findById(before.getId()).get();
+
+        // then
+        assertThat(after.getSavedAt()).isNotEqualTo(beforeSavedAt);
     }
 }

--- a/src/test/java/com/akkin/gulbi/GulbiReadTest.java
+++ b/src/test/java/com/akkin/gulbi/GulbiReadTest.java
@@ -120,4 +120,24 @@ public class GulbiReadTest extends UnitTest {
         // then
         assertThat(traffic.getEntries().isEmpty()).isTrue();
     }
+
+    @Test
+    public void 아낀_날짜_최근순으로_보여주기() {
+        // given
+        final int pageSize = 4;
+        Member member1 = memberRepository.save(회원1_만들기());
+        Gulbi gulbi1 = gulbiRepository.save(기타_500원_아낀_항목_만들기(member1, 2023, 9, 9));  // 3순위
+        Gulbi gulbi2 = gulbiRepository.save(교통_500원_아낀_항목_만들기(member1, 2023, 9, 8));  // 4순위
+        Gulbi gulbi3 = gulbiRepository.save(기타_500원_아낀_항목_만들기(member1, 2023, 9, 10)); // 1 순위
+        Gulbi gulbi4 = gulbiRepository.save(교통_500원_아낀_항목_만들기(member1, 2023, 9, 9));  // 2순위
+
+        // when
+        GulbiListResponse results = gulbiService.getGublis(member1.getId(), "", Long.MAX_VALUE, pageSize);
+
+        // then
+        assertThat(results.getElement(0).getId()).isEqualTo(gulbi3.getId());
+        assertThat(results.getElement(1).getId()).isEqualTo(gulbi4.getId());
+        assertThat(results.getElement(2).getId()).isEqualTo(gulbi1.getId());
+        assertThat(results.getElement(3).getId()).isEqualTo(gulbi2.getId());
+    }
 }

--- a/src/test/java/com/akkin/gulbi/GulbiUpdateTest.java
+++ b/src/test/java/com/akkin/gulbi/GulbiUpdateTest.java
@@ -20,7 +20,7 @@ public class GulbiUpdateTest extends UnitTest {
         // given
         Member member = memberRepository.save(회원1_만들기());
         Gulbi gulbi = gulbiRepository.save(기타_500원_아낀_항목_만들기(member, 2023, 9, 9));
-        GulbiUpdateForm form = new GulbiUpdateForm(2023, 9, 10, GulbiCategory.ETC, "content", "how", 100, 0);
+        GulbiUpdateForm form = new GulbiUpdateForm(2023, 9, 10, "imageUrl", GulbiCategory.ETC, "content", "how", 100, 0);
 
         // when
         gulbiService.update(member.getId(), gulbi.getId(), form);
@@ -36,7 +36,7 @@ public class GulbiUpdateTest extends UnitTest {
         Member member = memberRepository.save(회원1_만들기());
         Gulbi gulbi = gulbiRepository.save(기타_500원_아낀_항목_만들기(member, 2023, 9, 9));
         // 5000 원 아끼기
-        GulbiUpdateForm form = new GulbiUpdateForm(2023, 9, 10, GulbiCategory.ETC, "content", "how", 6000, 1000);
+        GulbiUpdateForm form = new GulbiUpdateForm(2023, 9, 10, "imageUrl", GulbiCategory.ETC, "content", "how", 6000, 1000);
 
         // when
         gulbiService.update(member.getId(), gulbi.getId(), form);
@@ -55,7 +55,7 @@ public class GulbiUpdateTest extends UnitTest {
         String newHow = "new_how";
         Gulbi gulbi = gulbiRepository.save(기타_500원_아낀_항목_만들기(member, 2023, 9, 9));
         // 5000 원 아끼기
-        GulbiUpdateForm form = new GulbiUpdateForm(2023, 9, 10, GulbiCategory.ETC, "content", newHow, 6000, 1000);
+        GulbiUpdateForm form = new GulbiUpdateForm(2023, 9, 10, "imageUrl", GulbiCategory.ETC, "content", newHow, 6000, 1000);
 
         // when
         gulbiService.update(member.getId(), gulbi.getId(), form);
@@ -72,7 +72,7 @@ public class GulbiUpdateTest extends UnitTest {
         String newContent = "new_content";
         Gulbi gulbi = gulbiRepository.save(기타_500원_아낀_항목_만들기(member, 2023, 9, 9));
         // 5000 원 아끼기
-        GulbiUpdateForm form = new GulbiUpdateForm(2023, 9, 10, GulbiCategory.ETC, newContent, "how", 6000, 1000);
+        GulbiUpdateForm form = new GulbiUpdateForm(2023, 9, 10, "imageUrl", GulbiCategory.ETC, newContent, "how", 6000, 1000);
 
         // when
         gulbiService.update(member.getId(), gulbi.getId(), form);
@@ -89,7 +89,7 @@ public class GulbiUpdateTest extends UnitTest {
         GulbiCategory newGulbiCategory = GulbiCategory.DINING;
         Gulbi gulbi = gulbiRepository.save(기타_500원_아낀_항목_만들기(member, 2023, 9, 9));
         // 5000 원 아끼기
-        GulbiUpdateForm form = new GulbiUpdateForm(2023, 9, 10, newGulbiCategory, "content", "how", 6000, 1000);
+        GulbiUpdateForm form = new GulbiUpdateForm(2023, 9, 10, "imageUrl", newGulbiCategory, "content", "how", 6000, 1000);
 
         // when
         gulbiService.update(member.getId(), gulbi.getId(), form);


### PR DESCRIPTION
삭제 시 500 response 발생
- 이전 커밋에서 Entity에 기본 생성자가 지워져서 생긴 문제였음

서버 시간과 실제 시간이 다른 문제 발생 해결
- DB의 시간을 현재 시간에 맞춤. 서울 리전이라 문제가 없을 거라 생각했지만, 시차가 있었다.

마지막에 생성된 아낀 날짜가 과거라면, 해당 정보를 최신 정보로 보는 문제 발생
- order by 첫 조건을 id가 아닌, savedAt 칼럼 기준으로 함

---
추가된 기능

- 하루에 아낀 항목 작성 횟수 제한(삭제, 수정은 X)
- 이미지 url 칼럼 추가
- swagger 웹 페이지에서 더미 유저로 테스트 가능하도록 변경